### PR TITLE
fixes links to github code examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/pytorch_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'pytorch-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/pytorch/pytorch_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'pytorch-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -293,7 +293,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/chainer_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'chainer-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/chainer/chainer_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'chainer-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -329,7 +329,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/tensorflow_eager_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'tensorflow-eager-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/tensorflow/tensorflow_eager_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'tensorflow-eager-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -371,7 +371,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/keras_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'keras-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/keras/keras_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'keras-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -411,7 +411,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/mxnet_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'mxnet-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/mxnet/mxnet_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'mxnet-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -447,7 +447,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/sklearn_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'sklearn-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/sklearn/sklearn_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'sklearn-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -486,7 +486,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/xgboost_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'xgboost-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/xgboost/xgboost_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'xgboost-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -531,7 +531,7 @@ def objective(trial):
 # 3. Create a study object and optimize the objective function.
 study = optuna.create_study(direction='maximize')
 study.optimize(objective, n_trials=100)</code></pre>
-														<a href="https://github.com/optuna/optuna/blob/master/examples/lightgbm_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'lightgbm-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
+														<a href="https://github.com/optuna/optuna-examples/blob/main/lightgbm/lightgbm_simple.py" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'lightgbm-example'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See full example on Github</button></a>
 													</p>
 												</div>
 											</div>
@@ -551,7 +551,7 @@ plot_intermediate_values(study)</code></pre>
 															<img src="assets/img/intermediate-values-graph.png" width="60%" class="card-top-shadow text-center">
 														</div>
 													</p>
-												<a href="https://github.com/optuna/optuna/tree/master/examples" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'more-examples'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See more examples on Github</button></a>
+												<a href="https://github.com/optuna/optuna-examples/blob/main/README.md" onClick="gtag('event', 'out', {'event_category': 'index.html','event_label': 'more-examples'});"><button class="btn btn-light" style="margin-top:10px; padding:5px 10px; font-size:15px;"><img src="https://icongr.am/octicons/chevron-right.svg?size=15&color=ffffff"> See more examples on Github</button></a>
 											</div>
 										</div>
 									</div>


### PR DESCRIPTION
Hello, the links to the examples in the github repo are broken, probably because the examples were migrated as per this issue:
https://github.com/optuna/optuna/issues/2654

